### PR TITLE
Preserve the original timezone for sun times

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ in the [Twilight article on Wikipedia](http://en.wikipedia.org/wiki/Twilight).
 
 ```php
 // initialise library class with date and coordinates today's sunlight times for Paris
-$sc = new SunCalc(new DateTime(), 48.85, 2.35);
+$sc = new AurorasLive\SunCalc(new DateTime(), 48.85, 2.35);
 
 // format sunrise time from the DateTime object
 $sunTimes = $sc->getSunTimes();
@@ -37,7 +37,7 @@ $sunriseAzimuth = $sunrisePos->azimuth * 180 / M_PI;
 ### Sunlight times
 
 ```php
-SunCalc :: getSunTimes()
+AurorasLive\SunCalc :: getSunTimes()
 ```
 
 Returns an array with the following indexes (each is a `DateTime` object):
@@ -65,7 +65,7 @@ Returns an array with the following indexes (each is a `DateTime` object):
 ### Sun position
 
 ```php
-SunCalc :: getSunPosition(/*DateTime*/ $timeAndDate)
+AurorasLive\SunCalc :: getSunPosition(/*DateTime*/ $timeAndDate)
 ```
 
 Returns an object with the following properties:
@@ -79,7 +79,7 @@ Returns an object with the following properties:
 ### Moon position
 
 ```php
-SunCalc :: getMoonPosition(/*DateTime*/ $timeAndDate)
+AurorasLive\SunCalc :: getMoonPosition(/*DateTime*/ $timeAndDate)
 ```
 
 Returns an object with the following properties:
@@ -92,7 +92,7 @@ Returns an object with the following properties:
 ### Moon illumination
 
 ```php
-SunCalc :: getMoonIllumination()
+AurorasLive\SunCalc :: getMoonIllumination()
 ```
 
 Returns an array with the following properties:
@@ -118,7 +118,7 @@ Moon phase value should be interpreted like this:
 ### Moon rise and set times
 
 ```php
-SunCalc :: getMoonTimes($inUTC)
+AurorasLive\SunCalc :: getMoonTimes($inUTC)
 ```
 
 Returns an object with the following indexes:
@@ -132,6 +132,14 @@ By default, it will search for moon rise and set during local user's day (from 0
 If `$inUTC` is set to true, it will instead search the specified date from 0 to 24 UTC hours.
 
 ## Changelog
+
+#### 0.0.2 &mdash; 21 Aug, 2018
+
+- Make this into a class and add a composer.json file to allow use with things like Laravel
+
+#### 0.0.1 &mdash; 29 Jul, 2017
+
+- Preserve original timezone when passing in dates
 
 #### 0.0.0 &mdash; 30 Dec, 2015
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "auroras-live/suncalc-php",
+    "description": "Sun and moon calculations for PHP",
+    "type": "library",
+    "license": "GPLv2",
+    "authors": [
+        {
+            "name": "David Gray and Greg Seth",
+            "email": "david@auroras.live"
+        }
+    ],
+    "require": {}
+}

--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,16 @@
 {
-    "name": "auroras-live/suncalc-php",
-    "description": "Sun and moon calculations for PHP",
-    "type": "library",
-    "license": "GPLv2",
-     "autoload": {
-        "files": [
-            "suncalc.php"
-        ],
-     },
-    "authors": [
-        {
-            "name": "David Gray and Greg Seth",
-            "email": "david@auroras.live"
-        }
-    ],
-    "require": {}
+	"name": "auroras-live/suncalc-php",
+	"description": "Sun and moon calculations for PHP",
+	"type": "library",
+	"license": "GPLv2",
+	"autoload": {
+		"files": [
+			"suncalc.php"
+		]
+	},
+	"authors": [{
+		"name": "David Gray and Greg Seth",
+		"email": "david@auroras.live"
+	}],
+	"require": {}
 }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,11 @@
     "description": "Sun and moon calculations for PHP",
     "type": "library",
     "license": "GPLv2",
+     "autoload": {
+        "files": [
+            "suncalc.php"
+        ],
+     },
     "authors": [
         {
             "name": "David Gray and Greg Seth",

--- a/suncalc.php
+++ b/suncalc.php
@@ -44,7 +44,7 @@ define('J0', 0.0009);
 function toJulian($date) { return $date->getTimestamp() / daySec - 0.5 + J1970; }
 function fromJulian($j, $d)  {
     if (!is_nan($j)) {
-        $dt = new DateTime("@".round(($j + 0.5 - J1970) * daySec));
+        $dt = new \DateTime("@".round(($j + 0.5 - J1970) * daySec));
         $dt->setTimezone($d->getTimezone());
         return $dt;
     }
@@ -275,7 +275,7 @@ class SunCalc {
 
     function getMoonTimes($inUTC=false) {
         $t = clone $this->date;
-        if ($inUTC) $t->setTimezone(new DateTimeZone('UTC'));
+        if ($inUTC) $t->setTimezone(new \DateTimeZone('UTC'));
 
         $t->setTime(0, 0, 0);
 
@@ -332,10 +332,9 @@ class SunCalc {
 
 // tests
 /*
-$test = new SunCalc(new DateTime(), 48.85, 2.35);
+$test = new SunCalc(new \DateTime(), 48.85, 2.35);
 print_r($test->getSunTimes());
 print_r($test->getMoonIllumination());
 print_r($test->getMoonTimes());
-print_r(getMoonPosition(new DateTime(), 48.85, 2.35));
+print_r(getMoonPosition(new \DateTime(), 48.85, 2.35));
 */
-?>

--- a/suncalc.php
+++ b/suncalc.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AurorasLive;
+
+use DateInterval;
+
 /*
  SunCalc is a PHP library for calculating sun/moon position and light phases.
  https://github.com/gregseth/suncalc-php

--- a/suncalc.php
+++ b/suncalc.php
@@ -38,10 +38,10 @@ define('J0', 0.0009);
 
 
 function toJulian($date) { return $date->getTimestamp() / daySec - 0.5 + J1970; }
-function fromJulian($j)  {
+function fromJulian($j, $d)  {
     if (!is_nan($j)) {
         $dt = new DateTime("@".round(($j + 0.5 - J1970) * daySec));
-        $dt->setTimezone((new DateTime())->getTimezone());
+        $dt->setTimezone($d->getTimezone());
         return $dt;
     }
 }
@@ -212,8 +212,8 @@ class SunCalc {
         $Jnoon = solarTransitJ($ds, $M, $L);
 
         $result = [
-            'solarNoon'=> fromJulian($Jnoon),
-            'nadir'    => fromJulian($Jnoon - 0.5)
+            'solarNoon'=> fromJulian($Jnoon, $this->date),
+            'nadir'    => fromJulian($Jnoon - 0.5, $this->date)
         ];
 
         for ($i = 0, $len = count($this->times); $i < $len; $i += 1) {
@@ -222,8 +222,8 @@ class SunCalc {
             $Jset = getSetJ($time[0] * rad, $lw, $phi, $dec, $n, $M, $L);
             $Jrise = $Jnoon - ($Jset - $Jnoon);
 
-            $result[$time[1]] = fromJulian($Jrise);
-            $result[$time[2]] = fromJulian($Jset);
+            $result[$time[1]] = fromJulian($Jrise, $this->date);
+            $result[$time[2]] = fromJulian($Jset, $this->date);
         }
 
         return $result;


### PR DESCRIPTION
fromJulian creates a new DateTime object, using whatever timezone in set in php.ini or wherever. If you construct SunCalc with your own timezone set, it's not preserved. This PR changes fromJulian to accept a DateTime object, and each of the four calls in SunCalc passes `$this->date`.